### PR TITLE
Màj liens complète

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'simplifica';
-  src: url('https://mlongmaths.github.io/mpsilamartin/fonts/simplifica.eot?#iefix') format('embedded-opentype'), 
-  url('https://mlongmaths.github.io/mpsilamartin/fonts/simplifica.woff') format('woff'), url('https://mlongmaths.github.io/mpsilamartin/fonts/simplifica.ttf') format('truetype');
+  src: url('/mpsilamartin/fonts/simplifica.eot?#iefix') format('embedded-opentype'), 
+  url('/mpsilamartin/fonts/simplifica.woff') format('woff'), url('/mpsilamartin/fonts/simplifica.ttf') format('truetype');
 }
 
 body {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-orga.html');
+      $('#target-nav-orga').load('/mpsilamartin/menus/nav-orga.html');
       });
    </script>  
                  

--- a/info.html
+++ b/info.html
@@ -11,7 +11,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/DM.html
+++ b/info/DM.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/DM_opt.html
+++ b/info/DM_opt.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>    
           

--- a/info/DS.html
+++ b/info/DS.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
   </head>

--- a/info/DS_2021-2022.html
+++ b/info/DS_2021-2022.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
   </head>

--- a/info/DS_opt.html
+++ b/info/DS_opt.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/TP.html
+++ b/info/TP.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/TP_opt.html
+++ b/info/TP_opt.html
@@ -13,7 +13,7 @@
     
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+	  $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
     </script>  
     

--- a/info/TP_opt/install_jupyter_ocaml.sh
+++ b/info/TP_opt/install_jupyter_ocaml.sh
@@ -56,7 +56,7 @@ ocaml-jupyter-opam-genspec
 jupyter kernelspec install --user --name ocaml-jupyter $(opam config var share)/jupyter
 
 # Téléchargement du fichier premiers pas
-wget https://mpsilamartin.github.io/info/TP_opt/ocaml_premiers_pas.ipynb
+wget /mpsilamartin/info/TP_opt/ocaml_premiers_pas.ipynb
 
 echo "------------------------------------------------------------------------------------------"
 echo "Vous pouvez désormais lancer JupyterLab à l'aide de la commande : jupyter lab --no-browser"

--- a/info/activites.html
+++ b/info/activites.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
   </head>

--- a/info/cours.html
+++ b/info/cours.html
@@ -12,7 +12,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/cours_opt.html
+++ b/info/cours_opt.html
@@ -12,7 +12,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
          </head>

--- a/info/envoi.html
+++ b/info/envoi.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi1.html
+++ b/info/mpsi1.html
@@ -12,7 +12,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi1/cdt_info_1.html
+++ b/info/mpsi1/cdt_info_1.html
@@ -17,7 +17,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mpsilamartin.github.io/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi1/ds_info_resultats_1.html
+++ b/info/mpsi1/ds_info_resultats_1.html
@@ -16,7 +16,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mpsilamartin.github.io/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi1/progs_cours_1.html
+++ b/info/mpsi1/progs_cours_1.html
@@ -16,7 +16,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mpsilamartin.github.io/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi2.html
+++ b/info/mpsi2.html
@@ -12,7 +12,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/info/mpsi2/progs_cours_2.html
+++ b/info/mpsi2/progs_cours_2.html
@@ -17,7 +17,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-info').load('https://mpsilamartin.github.io/menus/nav-info.html');
+      $('#target-nav-info').load('/mpsilamartin/menus/nav-info.html');
       });
    </script>  
    

--- a/langues.html
+++ b/langues.html
@@ -9,12 +9,12 @@
   	<title> MPSI La Martinière Monplaisir </title>
   	<style type="text/css" media="screen">@import url(css/style.css);</style>
 	<link rel="icon" href="img/favicon.png" type="image/png" />
-      <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>
+      <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      	 
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-langues.html');
+      $('#target-nav-langues').load('/mpsilamartin/menus/nav-langues.html');
       });
    </script>  
                  

--- a/langues/anglais.html
+++ b/langues/anglais.html
@@ -11,7 +11,7 @@
    <script type="text/javascript" src="../script/jquery-1.5.1.min.js"></script>
   	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-langues.html');
+      $('#target-nav-langues').load('/mpsilamartin/menus/nav-langues.html');
       });
    </script>  
                  

--- a/langues/anglais/DS.html
+++ b/langues/anglais/DS.html
@@ -11,7 +11,7 @@
    <script type="text/javascript" src="../../script/jquery-1.5.1.min.js"></script>
   	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-langues').load('https://mpsilamartin.github.io/menus/nav-langues.html');
+      $('#target-nav-langues').load('/mpsilamartin/menus/nav-langues.html');
       });
    </script>  
                  

--- a/langues/anglais/grammaire.html
+++ b/langues/anglais/grammaire.html
@@ -11,7 +11,7 @@
    <script type="text/javascript" src="../../script/jquery-1.5.1.min.js"></script>
   	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-langues').load('https://mpsilamartin.github.io/menus/nav-langues.html');
+      $('#target-nav-langues').load('/mpsilamartin/menus/nav-langues.html');
       });
    </script>  
                  

--- a/langues/anglais/voc.html
+++ b/langues/anglais/voc.html
@@ -11,7 +11,7 @@
    <script type="text/javascript" src="../../script/jquery-1.5.1.min.js"></script>
   	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-langues').load('https://mpsilamartin.github.io/menus/nav-langues.html');
+      $('#target-nav-langues').load('/mpsilamartin/menus/nav-langues.html');
       });
    </script>  
                  

--- a/maths.html
+++ b/maths.html
@@ -12,7 +12,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/DM.html
+++ b/maths/DM.html
@@ -14,7 +14,7 @@
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/DS.html
+++ b/maths/DS.html
@@ -14,7 +14,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/TD.html
+++ b/maths/TD.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/colles.html
+++ b/maths/colles.html
@@ -14,7 +14,7 @@
     
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours.html
+++ b/maths/cours.html
@@ -14,7 +14,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/.goutputstream-RPTRJ1
+++ b/maths/cours/.goutputstream-RPTRJ1
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/APL.html
+++ b/maths/cours/APL.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/APP.html
+++ b/maths/cours/APP.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/ARI.html
+++ b/maths/cours/ARI.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/ASY.html
+++ b/maths/cours/ASY.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/CAL.html
+++ b/maths/cours/CAL.html
@@ -11,7 +11,7 @@
     <script type="text/javascript" src="../../script/jquery-1.5.1.min.js"></script>
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
   </head>

--- a/maths/cours/COM.html
+++ b/maths/cours/COM.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/DEN.html
+++ b/maths/cours/DEN.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/DER.html
+++ b/maths/cours/DER.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/DET.html
+++ b/maths/cours/DET.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/DIM.html
+++ b/maths/cours/DIM.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/DVR.html
+++ b/maths/cours/DVR.html
@@ -13,7 +13,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/ENS.html
+++ b/maths/cours/ENS.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/EQD.html
+++ b/maths/cours/EQD.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/ESP.html
+++ b/maths/cours/ESP.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/EUC.html
+++ b/maths/cours/EUC.html
@@ -13,7 +13,7 @@
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/FAL.html
+++ b/maths/cours/FAL.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/FON.html
+++ b/maths/cours/FON.html
@@ -13,7 +13,7 @@
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/FRA.html
+++ b/maths/cours/FRA.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/GRO.html
+++ b/maths/cours/GRO.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/INT.html
+++ b/maths/cours/INT.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/LIM.html
+++ b/maths/cours/LIM.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/LOG.html
+++ b/maths/cours/LOG.html
@@ -13,7 +13,7 @@
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/MAL.html
+++ b/maths/cours/MAL.html
@@ -13,7 +13,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/MAT.html
+++ b/maths/cours/MAT.html
@@ -13,7 +13,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/POL.html
+++ b/maths/cours/POL.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/PRO.html
+++ b/maths/cours/PRO.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/REE.html
+++ b/maths/cours/REE.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/SER.html
+++ b/maths/cours/SER.html
@@ -13,7 +13,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/cours/SUI.html
+++ b/maths/cours/SUI.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/TIN.html
+++ b/maths/cours/TIN.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/cours/TRI.html
+++ b/maths/cours/TRI.html
@@ -12,7 +12,7 @@
                   
     <script type="text/javascript">
       $(document).ready(function(){
-	  $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+	  $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
     </script>  
     

--- a/maths/mp2i.html
+++ b/maths/mp2i.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mp2i/DS.html
+++ b/maths/mp2i/DS.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MP2I La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mp2i/cdt.html
+++ b/maths/mp2i/cdt.html
@@ -7,15 +7,15 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MP2I La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    
@@ -49,13 +49,15 @@ MP2I La Martinière Monplaisir<br>
 <span style="font-weight:bold">Vendredi 14 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-ch XXX §2.4 et §2.5</li>
+ch XXX §2.4 et §2.5
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 13 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-ch XXX §2.3 et §2.4</li>
+ch XXX §2.3 et §2.4
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 12 juin 2024</span>
@@ -75,20 +77,23 @@ Exercices
 <span style="font-weight:bold">Lundi 10 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-Exercices</li>
+Exercices
+</li>
 </ul>
 
 <a name="haut"></a>
 <span style="font-weight:bold">Vendredi 7 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXIX §2.4 à §2.7</li>
+ chXXIX §2.4 à §2.7
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 6 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXIX §2.3</li>
+ chXXIX §2.3
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 5 juin 2024</span>
@@ -108,19 +113,22 @@ Exercices</li>
 <span style="font-weight:bold">Lundi 3 juin 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVIII §5.2</li>
+ chXXVIII §5.2
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 31 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- </li>
+ 
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 30 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVIII §5.1</li>
+ chXXVIII §5.1
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 29 mai 2024</span>
@@ -140,19 +148,22 @@ Exercices</li>
 <span style="font-weight:bold">Lundi 27 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVIII §2</li>
+ chXXVIII §2
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 24 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVIII §1</li>
+ chXXVIII §1
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 23 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVII §5</li>
+ chXXVII §5
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 22 mai 2024</span>
@@ -172,19 +183,22 @@ chXXVII §2 et §3.1
 <span style="font-weight:bold">Lundi 20 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-Férié</li>
+Férié
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 17 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVII §1</li>
+ chXXVII §1
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 16 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- chXXVI §6</li>
+ chXXVI §6
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 15 mai 2024</span>
@@ -204,19 +218,22 @@ chXXVI §4
 <span style="font-weight:bold">Lundi 13 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXVI §3</li>
+chXXVI §3
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 10 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-Pont</li>
+Pont
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 9 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-Férié</li>
+Férié
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 8 mai 2024</span>
@@ -236,19 +253,22 @@ chXXVI §2.3 et §2.4
 <span style="font-weight:bold">Lundi 6 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXVI §1, §2.1 et §2.2</li>
+chXXVI §1, §2.1 et §2.2
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 3 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXV §2.8</li>
+chXXV §2.8
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 2 mai 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXV §2.7</li>
+chXXV §2.7
+</li>
 </ul>
 
 <span style="font-weight:bold">Mercredi 1 mai 2024</span>
@@ -268,19 +288,22 @@ chXXV §2.6
 <span style="font-weight:bold">Lundi 29 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXV §2.5</li>
+chXXV §2.5
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 12 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXV §2.4</li>
+chXXV §2.4
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 11 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXV  §1.4, §2.1 et §2.2</li>
+chXXV  §1.4, §2.1 et §2.2
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 10 avril 2024</span>
 <ul class="itemize">
@@ -299,19 +322,22 @@ chXXV §1.1 à §1.2
 <span style="font-weight:bold">Lundi 8 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXIV §4</li>
+chXXIV §4
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 5 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXIV §3</li>
+chXXIV §3
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 4 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXIV §2.1 à §2.3</li>
+chXXIV §2.1 à §2.3
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 3 avril 2024</span>
 <ul class="itemize">
@@ -330,19 +356,22 @@ chXXIV §1.1 à §1.3
 <span style="font-weight:bold">Lundi 1 avril 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
- Férié</li>
+ Férié
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 29 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXIII §2 </li>
+chXXIII §2 
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 28 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXIII §1</li>
+chXXIII §1
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 27 mars 2024</span>
 <ul class="itemize">
@@ -361,19 +390,22 @@ chXXII §7
 <span style="font-weight:bold">Lundi 25 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXII §5 et §6</li>
+chXXII §5 et §6
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 22 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXII §2.3 et §3 </li>
+chXXII §2.3 et §3 
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 21 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXII §2.2 </li>
+chXXII §2.2 
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 20 mars 2024</span>
 <ul class="itemize">
@@ -392,19 +424,22 @@ chXXI §3
 <span style="font-weight:bold">Lundi 18 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXI §2.5 à partir du théorème 2.5.17 au §2.6</li>
+chXXI §2.5 à partir du théorème 2.5.17 au §2.6
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 15 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXI §2.4 à §2.6</li>
+chXXI §2.4 à §2.6
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 14 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXXI §2.1 à §2.3</li>
+chXXI §2.1 à §2.3
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 13 mars 2024</span>
 <ul class="itemize">
@@ -423,20 +458,23 @@ chXXI §1.1 et §1.2
 <span style="font-weight:bold">Lundi 11 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXX §4 </li>
+chXX §4 
+</li>
 </ul>
 
 
 <span style="font-weight:bold">Vendredi 8 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXX §3.5</li>
+chXX §3.5
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 7 mars 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXX §3.3 et §3.4</li>
+chXX §3.3 et §3.4
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 6 mars 2024</span>
 <ul class="itemize">
@@ -458,13 +496,15 @@ chXX §1.4 à §2.2
 chXIX§3
 </li>
 <li class="li-itemize">
-chXX §1.1 à §1.3</li>
+chXX §1.1 à §1.3
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 16 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXIX §2.3c à §2.4 </li>
+chXIX §2.3c à §2.4 
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 15 février 2024</span>
@@ -476,7 +516,8 @@ chXIX §1 §2.1 à §2.3b
 TD18: ex1 et ex2
 </li>
 <li class="li-itemize">
-TD17: ex17 et ex19</li>
+TD17: ex17 et ex19
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 14 février 2024</span>
 <ul class="itemize">
@@ -494,20 +535,23 @@ TD17: ex17 et ex19</li>
 <span style="font-weight:bold">Lundi 12 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-</li>
+
+</li>
 </ul>
 
 
 <span style="font-weight:bold">Vendredi 9 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXVIII §2.6 à §3</li>
+chXVIII §2.6 à §3
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 8 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXVIII §2.5  </li>
+chXVIII §2.5  
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 7 février 2024</span>
 <ul class="itemize">
@@ -526,19 +570,22 @@ chXVIII §2.5  </li>
 <span style="font-weight:bold">Lundi 5 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXVII §4.3 </li>
+chXVII §4.3 
+</li>
 </ul>
 
 <span style="font-weight:bold">Vendredi 2 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXVII §4.2 </li>
+chXVII §4.2 
+</li>
 </ul>
 
 <span style="font-weight:bold">Jeudi 1 février 2024</span>
 <ul class="itemize">
 <li class="li-itemize">
-chXVII §2.6 à §3  </li>
+chXVII §2.6 à §3  
+</li>
 </ul>
 <span style="font-weight:bold">Mercredi 31 janvier 2024</span>
 <ul class="itemize">

--- a/maths/mp2i/interros.html
+++ b/maths/mp2i/interros.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MP2I La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi1.html
+++ b/maths/mpsi1.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi1/cdt_maths_1.html
+++ b/maths/mpsi1/cdt_maths_1.html
@@ -18,7 +18,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi1/ds_maths_resultats_1.html
+++ b/maths/mpsi1/ds_maths_resultats_1.html
@@ -16,12 +16,12 @@
         
  <script type="text/javascript">
       $(document).ready(function(){
-      $('#target-onglet-orga').load('https://mpsilamartin.github.io/menus/onglet-orga.html');
+      $('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
     </script>    
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi1/exosupp.html
+++ b/maths/mpsi1/exosupp.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi1/interros_1.html
+++ b/maths/mpsi1/interros_1.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2.html
+++ b/maths/mpsi2.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/.goutputstream-S4R3T1
+++ b/maths/mpsi2/.goutputstream-S4R3T1
@@ -7,15 +7,15 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/DS.html
+++ b/maths/mpsi2/DS.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/QCM.html
+++ b/maths/mpsi2/QCM.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/cdt.html
+++ b/maths/mpsi2/cdt.html
@@ -7,15 +7,15 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/exosupp.html
+++ b/maths/mpsi2/exosupp.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/maths/mpsi2/interros.html
+++ b/maths/mpsi2/interros.html
@@ -6,16 +6,16 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
 	
-	<script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+	<script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
      		
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-maths').load('https://mpsilamartin.github.io/menus/nav-maths.html');
+      $('#target-nav-maths').load('/mpsilamartin/menus/nav-maths.html');
       });
    </script>  
    

--- a/menus/nav-info.html
+++ b/menus/nav-info.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-actif-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/nav-langues.html
+++ b/menus/nav-langues.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-actif-langues.html');
       });
 </script> 
 

--- a/menus/nav-maths.html
+++ b/menus/nav-maths.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-actif-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/nav-orga.html
+++ b/menus/nav-orga.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-actif-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/nav-physique.html
+++ b/menus/nav-physique.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-actif-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/nav-sii.html
+++ b/menus/nav-sii.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-actif-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/nav-tipe.html
+++ b/menus/nav-tipe.html
@@ -1,42 +1,42 @@
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-orga.html');
+   	$('#target-onglet-orga').load('/mpsilamartin/menus/onglet-orga.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-maths').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-maths.html');
+   	$('#target-onglet-maths').load('/mpsilamartin/menus/onglet-maths.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-physique.html');
+   	$('#target-onglet-physique').load('/mpsilamartin/menus/onglet-physique.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-info').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-info.html');
+   	$('#target-onglet-info').load('/mpsilamartin/menus/onglet-info.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-sii.html');
+   	$('#target-onglet-sii').load('/mpsilamartin/menus/onglet-sii.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-actif-tipe.html');
+   	$('#target-onglet-tipe').load('/mpsilamartin/menus/onglet-actif-tipe.html');
       });
 </script> 
 
 <script type="text/javascript">
 		$(document).ready(function(){
-   	$('#target-onglet-langues').load('https://mlongmaths.github.io/mpsilamartin/menus/onglet-langues.html');
+   	$('#target-onglet-langues').load('/mpsilamartin/menus/onglet-langues.html');
       });
 </script> 
 

--- a/menus/onglet-actif-info.html
+++ b/menus/onglet-actif-info.html
@@ -1,13 +1,13 @@
-<a id="actif3" href="https://mlongmaths.github.io/mpsilamartin/info.html"> Info </a>
+<a id="actif3" href="/mpsilamartin/info.html"> Info </a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/cours.html"> Cours tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/TP.html"> TP tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DM.html"> DM tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/activites.html"> Activités tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DS.html"> DS tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/cours_opt.html"> Cours option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/TP_opt.html"> TP option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DM_opt.html"> DM option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DS_opt.html"> DS  option</a></li>
-  <!--<li><a href="https://mlongmaths.github.io/mpsilamartin/info/envoi.html"> Envoi de fichiers </a></li>-->
+  <li><a href="/mpsilamartin/info/cours.html"> Cours tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/TP.html"> TP tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/DM.html"> DM tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/activites.html"> Activités tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/DS.html"> DS tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/cours_opt.html"> Cours option</a></li>
+  <li><a href="/mpsilamartin/info/TP_opt.html"> TP option</a></li>
+  <li><a href="/mpsilamartin/info/DM_opt.html"> DM option</a></li>
+  <li><a href="/mpsilamartin/info/DS_opt.html"> DS  option</a></li>
+  <!--<li><a href="/mpsilamartin/info/envoi.html"> Envoi de fichiers </a></li>-->
 </ul>

--- a/menus/onglet-actif-langues.html
+++ b/menus/onglet-actif-langues.html
@@ -1,4 +1,4 @@
-<a id="actif6" href="https://mlongmaths.github.io/mpsilamartin/langues.html" > LV </a> 
+<a id="actif6" href="/mpsilamartin/langues.html" > LV </a> 
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/langues/anglais.html"> Anglais &nbsp;</a> </li>
+  <li><a href="/mpsilamartin/langues/anglais.html"> Anglais &nbsp;</a> </li>
 </ul>

--- a/menus/onglet-actif-maths.html
+++ b/menus/onglet-actif-maths.html
@@ -1,11 +1,11 @@
-<a id="actif1" href="https://mlongmaths.github.io/mpsilamartin/maths.html"> Maths </a>
+<a id="actif1" href="/mpsilamartin/maths.html"> Maths </a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/cours.html"> Cours </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/colles.html"> Colles </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/TD.html"> TD </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/DM.html"> DM </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/DS.html"> DS </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mpsi1.html"> MPSI 1 </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mpsi2.html"> MPSI 2 </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mp2i.html"> MP2I </a></li>
+  <li><a href="/mpsilamartin/maths/cours.html"> Cours </a></li>
+  <li><a href="/mpsilamartin/maths/colles.html"> Colles </a></li>
+  <li><a href="/mpsilamartin/maths/TD.html"> TD </a></li>
+  <li><a href="/mpsilamartin/maths/DM.html"> DM </a></li>
+  <li><a href="/mpsilamartin/maths/DS.html"> DS </a></li>
+  <li><a href="/mpsilamartin/maths/mpsi1.html"> MPSI 1 </a></li>
+  <li><a href="/mpsilamartin/maths/mpsi2.html"> MPSI 2 </a></li>
+  <li><a href="/mpsilamartin/maths/mp2i.html"> MP2I </a></li>
 </ul>

--- a/menus/onglet-actif-orga.html
+++ b/menus/onglet-actif-orga.html
@@ -1,6 +1,6 @@
-<a id="actif0" href="https://mlongmaths.github.io/mpsilamartin/index.html" > Orga </a> 
+<a id="actif0" href="/mpsilamartin/index.html" > Orga </a> 
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mpsi1.html"> MPSI 1 &nbsp;</a> </li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mpsi2.html"> MPSI 2 &nbsp;</a> </li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mp2i.html"> MP2I &nbsp;</a> </li>
+  <li><a href="/mpsilamartin/orga/mpsi1.html"> MPSI 1 &nbsp;</a> </li>
+  <li><a href="/mpsilamartin/orga/mpsi2.html"> MPSI 2 &nbsp;</a> </li>
+  <li><a href="/mpsilamartin/orga/mp2i.html"> MP2I &nbsp;</a> </li>
 </ul>

--- a/menus/onglet-actif-physique.html
+++ b/menus/onglet-actif-physique.html
@@ -1,6 +1,6 @@
-<a id="actif2" href="https://mlongmaths.github.io/mpsilamartin/physique.html"> Physique </a>
+<a id="actif2" href="/mpsilamartin/physique.html"> Physique </a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/physique/Programme-physique&chimie-MPSI-2013.pdf"> Programmes officiels </a></li>
+  <li><a href="/mpsilamartin/physique/Programme-physique&chimie-MPSI-2013.pdf"> Programmes officiels </a></li>
   <li><a href="https://cahier-de-prepa.fr/mpsi1-la-martin/?accueil"> MPSI 1</a></li>       
   <li><a href="http://cahier-de-prepa.fr/mpsi2-la-martin/"> MPSI 2</a></li>    
   <li><a href="https://cahier-de-prepa.fr/mp2i-martiniere-monplaisir/"> MP2I</a></li>

--- a/menus/onglet-actif-sii.html
+++ b/menus/onglet-actif-sii.html
@@ -1,4 +1,4 @@
-<a id="actif5" href="https://mlongmaths.github.io/mpsilamartin/physique.html"> SII </a>
+<a id="actif5" href="/mpsilamartin/physique.html"> SII </a>
 <ul>     
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/sii/mpsi2.html"> MPSI 2</a></li>
+  <li><a href="/mpsilamartin/sii/mpsi2.html"> MPSI 2</a></li>
 </ul>

--- a/menus/onglet-actif-tipe.html
+++ b/menus/onglet-actif-tipe.html
@@ -1,4 +1,4 @@
-<a id="actif4" href="https://mlongmaths.github.io/mpsilamartin/tipe.html"> TIPE </a>
+<a id="actif4" href="/mpsilamartin/tipe.html"> TIPE </a>
     <ul>
       <li><a href="TIPE/presentation_TIPE_MPSI.pdf" target="_blank"> Présentation TIPE &nbsp;</a></li>
 	<li><a href="TIPE/suivi_TIPE.pdf" target="_blank"> Fiche de suivi &nbsp;</a></li>

--- a/menus/onglet-info.html
+++ b/menus/onglet-info.html
@@ -1,15 +1,15 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/info.html"> Info </a>
+<a href="/mpsilamartin/info.html"> Info </a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/cours.html"> Cours tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/TP.html"> TP tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DM.html"> DM tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/activites.html"> Activités tronc commun</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DS.html"> DS  tronc commun</a></li>
-  <!-- <li><a href="https://mlongmaths.github.io/mpsilamartin/info/mpsi1.html"> MPSI 1  tronc commun</a></li> -->
-  <!-- <li><a href="https://mlongmaths.github.io/mpsilamartin/info/mpsi2.html"> MPSI 2  tronc commun</a></li> -->
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/cours_opt.html"> Cours option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/TP_opt.html"> TP option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DM_opt.html"> DM option</a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/info/DS_opt.html"> DS  option</a></li>
-  <!--<li><a href="https://mlongmaths.github.io/mpsilamartin/info/envoi.html"> Envoi de fichiers </a></li>-->
+  <li><a href="/mpsilamartin/info/cours.html"> Cours tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/TP.html"> TP tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/DM.html"> DM tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/activites.html"> Activités tronc commun</a></li>
+  <li><a href="/mpsilamartin/info/DS.html"> DS  tronc commun</a></li>
+  <!-- <li><a href="/mpsilamartin/info/mpsi1.html"> MPSI 1  tronc commun</a></li> -->
+  <!-- <li><a href="/mpsilamartin/info/mpsi2.html"> MPSI 2  tronc commun</a></li> -->
+  <li><a href="/mpsilamartin/info/cours_opt.html"> Cours option</a></li>
+  <li><a href="/mpsilamartin/info/TP_opt.html"> TP option</a></li>
+  <li><a href="/mpsilamartin/info/DM_opt.html"> DM option</a></li>
+  <li><a href="/mpsilamartin/info/DS_opt.html"> DS  option</a></li>
+  <!--<li><a href="/mpsilamartin/info/envoi.html"> Envoi de fichiers </a></li>-->
 </ul>

--- a/menus/onglet-langues.html
+++ b/menus/onglet-langues.html
@@ -1,4 +1,4 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/langues.html" > LV </a> 
+<a href="/mpsilamartin/langues.html" > LV </a> 
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/langues/anglais.html"> Anglais &nbsp;</a> </li>
+  <li><a href="/mpsilamartin/langues/anglais.html"> Anglais &nbsp;</a> </li>
 </ul>

--- a/menus/onglet-maths.html
+++ b/menus/onglet-maths.html
@@ -1,11 +1,11 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/maths.html"> Maths </a>
+<a href="/mpsilamartin/maths.html"> Maths </a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/cours.html"> Cours </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/colles.html"> Colles </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/TD.html"> TD </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/DM.html"> DM </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/DS.html"> DS </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mpsi1.html"> MPSI 1 </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mpsi2.html"> MPSI 2 </a></li>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/maths/mp2i.html"> MP2I </a></li>
+  <li><a href="/mpsilamartin/maths/cours.html"> Cours </a></li>
+  <li><a href="/mpsilamartin/maths/colles.html"> Colles </a></li>
+  <li><a href="/mpsilamartin/maths/TD.html"> TD </a></li>
+  <li><a href="/mpsilamartin/maths/DM.html"> DM </a></li>
+  <li><a href="/mpsilamartin/maths/DS.html"> DS </a></li>
+  <li><a href="/mpsilamartin/maths/mpsi1.html"> MPSI 1 </a></li>
+  <li><a href="/mpsilamartin/maths/mpsi2.html"> MPSI 2 </a></li>
+  <li><a href="/mpsilamartin/maths/mp2i.html"> MP2I </a></li>
 </ul>

--- a/menus/onglet-orga.html
+++ b/menus/onglet-orga.html
@@ -1,5 +1,5 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/index.html" > Orga </a> <ul>
-		<li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mpsi1.html"> MPSI 1 &nbsp;</a> </li>
-		<li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mpsi2.html"> MPSI 2 &nbsp;</a> </li>
-		<li><a href="https://mlongmaths.github.io/mpsilamartin/orga/mp2i.html"> MP2I &nbsp;</a> </li>
+<a href="/mpsilamartin/index.html" > Orga </a> <ul>
+		<li><a href="/mpsilamartin/orga/mpsi1.html"> MPSI 1 &nbsp;</a> </li>
+		<li><a href="/mpsilamartin/orga/mpsi2.html"> MPSI 2 &nbsp;</a> </li>
+		<li><a href="/mpsilamartin/orga/mp2i.html"> MP2I &nbsp;</a> </li>
     </ul>

--- a/menus/onglet-physique.html
+++ b/menus/onglet-physique.html
@@ -1,6 +1,6 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/physique.html"> Physique</a>
+<a href="/mpsilamartin/physique.html"> Physique</a>
 <ul>
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/physique/Programme-physique&chimie-MPSI-2013.pdf"> Programmes officiels </a></li>
+  <li><a href="/mpsilamartin/physique/Programme-physique&chimie-MPSI-2013.pdf"> Programmes officiels </a></li>
   <li><a href="https://cahier-de-prepa.fr/mpsi1-la-martin/?accueil"> MPSI 1</a></li>       
   <li><a href="http://cahier-de-prepa.fr/mpsi2-la-martin/"> MPSI 2</a></li>
   <li><a href="https://cahier-de-prepa.fr/mp2i-martiniere-monplaisir/"> MP2I</a></li>

--- a/menus/onglet-sii.html
+++ b/menus/onglet-sii.html
@@ -1,4 +1,4 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/sii.html"> SII</a>
+<a href="/mpsilamartin/sii.html"> SII</a>
 <ul> 
-  <li><a href="https://mlongmaths.github.io/mpsilamartin/sii/mpsi2.html"> MPSI 2</a></li>
+  <li><a href="/mpsilamartin/sii/mpsi2.html"> MPSI 2</a></li>
 </ul>

--- a/menus/onglet-tipe.html
+++ b/menus/onglet-tipe.html
@@ -1,4 +1,4 @@
-<a href="https://mlongmaths.github.io/mpsilamartin/tipe.html"> TIPE </a>
+<a href="/mpsilamartin/tipe.html"> TIPE </a>
     <ul>
       <li><a href="TIPE/presentation_TIPE_MPSI.pdf" target="_blank"> Présentation TIPE &nbsp;</a></li>
 	<li><a href="TIPE/suivi_TIPE.pdf" target="_blank"> Fiche de suivi &nbsp;</a></li>

--- a/orga/.render_temp_mp2i.html
+++ b/orga/.render_temp_mp2i.html
@@ -11,7 +11,7 @@
        
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-orga').load('https://mpsilamartin.github.io/menus/nav-orga.html');
+      $('#target-nav-orga').load('/mpsilamartin/menus/nav-orga.html');
       });
    </script>  
                  

--- a/orga/mp2i.html
+++ b/orga/mp2i.html
@@ -11,7 +11,7 @@
        
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-orga.html');
+      $('#target-nav-orga').load('/mpsilamartin/menus/nav-orga.html');
       });
    </script>  
                  

--- a/orga/mpsi1.html
+++ b/orga/mpsi1.html
@@ -12,7 +12,7 @@
       
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-orga.html');
+      $('#target-nav-orga').load('/mpsilamartin/menus/nav-orga.html');
       });
    </script>  
                  

--- a/orga/mpsi2.html
+++ b/orga/mpsi2.html
@@ -11,7 +11,7 @@
        
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-orga').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-orga.html');
+      $('#target-nav-orga').load('/mpsilamartin/menus/nav-orga.html');
       });
    </script>  
                  

--- a/physique.html
+++ b/physique.html
@@ -9,11 +9,11 @@
   	<title> MPSI La Martinière Monplaisir </title>
   	<style type="text/css" media="screen">@import url(css/style.css);</style>
 	<link rel="icon" href="img/favicon.png" type="image/png" />
-      <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>   		
+      <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>   		
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-physique.html');
+      $('#target-nav-physique').load('/mpsilamartin/menus/nav-physique.html');
       });
    </script>  
    

--- a/physique/mpsi1.html
+++ b/physique/mpsi1.html
@@ -6,14 +6,14 @@
     <meta http-equiv="Content-Language" content="fr">
     <meta name=viewport content="width=device-width, initial-scale=1">
     <title>MPSI 1 La Martinière Monplaisir </title>
-    <style type="text/css" media="screen">@import url(https://mlongmaths.github.io/mpsilamartin/css/style.css);</style>
-    <link rel="icon" href="https://mlongmaths.github.io/mpsilamartin/img/favicon.png" type="image/png" />
-    <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>
+    <style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+    <link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+    <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
     
   
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-physique.html');
+      $('#target-nav-physique').load('/mpsilamartin/menus/nav-physique.html');
       });
    </script>  
    

--- a/physique/mpsi1/colles_pc_mpsi1.html
+++ b/physique/mpsi1/colles_pc_mpsi1.html
@@ -6,14 +6,14 @@
     <meta http-equiv="Content-Language" content="fr">
     <meta name=viewport content="width=device-width, initial-scale=1">
     <title>MPSI 1 La Martinière Monplaisir </title>
-    <style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-    <link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
-    <script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+    <style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+    <link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+    <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
     
   
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-physique').load('https://mpsilamartin.github.io/menus/nav-physique.html');
+      $('#target-nav-physique').load('/mpsilamartin/menus/nav-physique.html');
       });
    </script>  
    

--- a/physique/mpsi2.html
+++ b/physique/mpsi2.html
@@ -6,14 +6,14 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mlongmaths.github.io/mpsilamartin/css/style.css);</style>
-	<link rel="icon" href="https://mlongmaths.github.io/mpsilamartin/img/favicon.png" type="image/png" />
-   <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+   <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
   
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-physique').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-physique.html');
+      $('#target-nav-physique').load('/mpsilamartin/menus/nav-physique.html');
       });
    </script>  
    

--- a/sii.html
+++ b/sii.html
@@ -9,12 +9,12 @@
   	<title> MPSI La Martinière Monplaisir </title>
   	<style type="text/css" media="screen">@import url(css/style.css);</style>
 	<link rel="icon" href="img/favicon.png" type="image/png" />
-      <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>
+      <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/sii/mpsi2.html
+++ b/sii/mpsi2.html
@@ -6,14 +6,14 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mlongmaths.github.io/mpsilamartin/css/style.css);</style>
-	<link rel="icon" href="https://mlongmaths.github.io/mpsilamartin/img/favicon.png" type="image/png" />
-   <script type="text/javascript" src="https://mlongmaths.github.io/mpsilamartin/script/jquery-1.5.1.min.js"></script>
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+   <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/sii/mpsi2/TD.html
+++ b/sii/mpsi2/TD.html
@@ -6,14 +6,14 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
-   <script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+   <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mpsilamartin.github.io/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/sii/mpsi2/TD0.html
+++ b/sii/mpsi2/TD0.html
@@ -14,7 +14,7 @@
      
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mpsilamartin.github.io/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/sii/mpsi2/TP.html
+++ b/sii/mpsi2/TP.html
@@ -6,14 +6,14 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
-   <script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+   <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mpsilamartin.github.io/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/sii/mpsi2/cours.html
+++ b/sii/mpsi2/cours.html
@@ -6,14 +6,14 @@
   	<meta http-equiv="Content-Language" content="fr">
   	<meta name=viewport content="width=device-width, initial-scale=1">
   	<title> MPSI 2 La Martinière Monplaisir </title>
-  	<style type="text/css" media="screen">@import url(https://mpsilamartin.github.io/css/style.css);</style>
-	<link rel="icon" href="https://mpsilamartin.github.io/img/favicon.png" type="image/png" />
-   <script type="text/javascript" src="https://mpsilamartin.github.io/script/jquery-1.5.1.min.js"></script>
+  	<style type="text/css" media="screen">@import url(/mpsilamartin/css/style.css);</style>
+	<link rel="icon" href="/mpsilamartin/img/favicon.png" type="image/png" />
+   <script type="text/javascript" src="/mpsilamartin/script/jquery-1.5.1.min.js"></script>
         
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-sii').load('https://mpsilamartin.github.io/menus/nav-sii.html');
+      $('#target-nav-sii').load('/mpsilamartin/menus/nav-sii.html');
       });
    </script>  
    

--- a/tipe.html
+++ b/tipe.html
@@ -13,7 +13,7 @@
     
 	<script type="text/javascript">
       $(document).ready(function(){
-      $('#target-nav-tipe').load('https://mlongmaths.github.io/mpsilamartin/menus/nav-tipe.html');
+      $('#target-nav-tipe').load('/mpsilamartin/menus/nav-tipe.html');
       });
    </script>  
    


### PR DESCRIPTION
TL;DR: `https://mlongmaths.github.io/mpsilamartin/` et `https://mpsilamartin.github.io/` -> `/mpsilamartin/`

- Extension de la Màj des liens à tout les fichiers
- Usage de requêtes locales au lieu du protocole https pour accéder à des fichiers locaux

Résous par exemple l'état actuel de la page [maths/mp2i/cdt](https://mlongmaths.github.io/mpsilamartin/maths/mp2i/cdt.html)

Démo disponible [ici](https://jiler01.github.io/mpsilamartin)